### PR TITLE
android.util.FloatMath -> java.lang.Math

### DIFF
--- a/ChatDemoUI/src/com/easemob/chatuidemo/widget/photoview/VersionedGestureDetector.java
+++ b/ChatDemoUI/src/com/easemob/chatuidemo/widget/photoview/VersionedGestureDetector.java
@@ -32,7 +32,6 @@ package com.easemob.chatuidemo.widget.photoview;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
-import android.util.FloatMath;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.ScaleGestureDetector.OnScaleGestureListener;
@@ -121,7 +120,7 @@ public abstract class VersionedGestureDetector {
 					if (!mIsDragging) {
 						// Use Pythagoras to see if drag length is larger than
 						// touch slop
-						mIsDragging = FloatMath.sqrt((dx * dx) + (dy * dy)) >= mTouchSlop;
+						mIsDragging = Math.sqrt((dx * dx) + (dy * dy)) >= mTouchSlop;
 					}
 
 					if (mIsDragging) {


### PR DESCRIPTION
FloatMath routines similar to those found in {@link java.lang.Math}.
Historically these methods were faster than the equivalent double-based {@link java.lang.Math} methods. On versions of Android with a JIT they became slower and have since been re-implemented to wrap calls to {@link java.lang.Math}. {@link java.lang.Math} should be used in preference.
All methods were removed from the public API in version 23.(Android M)